### PR TITLE
Fixes 7: Fix defaults

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -123,7 +123,7 @@ class Config implements ConfigInterface
      *
      * @return Data
      */
-    public function getDefaults()
+    protected function getDefaults()
     {
         // Ensure $this->defaults is a Data object (not an array)
         if (is_array($this->defaults)) {
@@ -140,7 +140,7 @@ class Config implements ConfigInterface
      *
      * @throws \Exception
      */
-    public function setDefaults($defaults)
+    protected function setDefaults($defaults)
     {
         if (is_array($defaults)) {
             $this->defaults = new Data($defaults);

--- a/src/Config.php
+++ b/src/Config.php
@@ -14,7 +14,7 @@ class Config implements ConfigInterface
      * TODO: make this private in 2.0 to prevent being saved as an array
      *   Making private now breaks backward compatibility
      *
-     * @var Data $defaults
+     * @var Data
      */
     protected $defaults;
 
@@ -124,14 +124,19 @@ class Config implements ConfigInterface
      * TODO: remove Data object validation in 2.0
      *
      * @return Data
+     * @throws \Exception
      */
     protected function getDefaults()
     {
         // Ensure $this->defaults is a Data object (not an array)
         if (is_array($this->defaults)) {
             $this->setDefaults($this->defaults);
+            return $this->getDefaults();
+        } elseif ($this->defaults instanceof Data) {
+            return $this->defaults;
+        } else {
+            throw new \Exception('$this->defaults is not a DflyDev\DotAccessData\Data object');
         }
-        return $this->defaults;
     }
 
     /**

--- a/src/Config.php
+++ b/src/Config.php
@@ -11,6 +11,9 @@ class Config implements ConfigInterface
     protected $config;
 
     /**
+     * TODO: make this private in 2.0 to prevent being saved as an array
+     *   Making private now breaks backward compatibility
+     *
      * @var Data
      */
     protected $defaults;
@@ -22,7 +25,7 @@ class Config implements ConfigInterface
     public function __construct(array $data = null)
     {
         $this->config = new Data($data);
-        $this->defaults = new Data();
+        $this->setDefaults(new Data());
     }
 
     /**
@@ -94,7 +97,7 @@ class Config implements ConfigInterface
      */
     public function hasDefault($key)
     {
-        return $this->defaults->has($key);
+        return $this->getDefaults()->has($key);
     }
 
     /**
@@ -102,7 +105,7 @@ class Config implements ConfigInterface
      */
     public function getDefault($key, $defaultFallback = null)
     {
-        return $this->hasDefault($key) ? $this->defaults->get($key) : $defaultFallback;
+        return $this->hasDefault($key) ? $this->getDefaults()->get($key) : $defaultFallback;
     }
 
     /**
@@ -110,7 +113,41 @@ class Config implements ConfigInterface
      */
     public function setDefault($key, $value)
     {
-        $this->defaults->set($key, $value);
+        $this->getDefaults()->set($key, $value);
         return $this;
+    }
+
+    /**
+     * Return the class $defaults property and ensure it's a Data object
+     * TODO: remove Data object validation in 2.0
+     *
+     * @return Data
+     */
+    public function getDefaults()
+    {
+        // Ensure $this->defaults is a Data object (not an array)
+        if (is_array($this->defaults)) {
+            $this->setDefaults($this->defaults);
+        }
+        return $this->defaults;
+    }
+
+    /**
+     * Sets the $defaults class parameter
+     * TODO: remove support for array in 2.0 as this would currently break backward compatibility
+     *
+     * @param Data|array $defaults
+     *
+     * @throws \Exception
+     */
+    public function setDefaults($defaults)
+    {
+        if (is_array($defaults)) {
+            $this->defaults = new Data($defaults);
+        } elseif ($defaults instanceof Data) {
+            $this->defaults = $defaults;
+        } else {
+            throw new \Exception("Unknown type provided for \$defaults");
+        }
     }
 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -21,6 +21,8 @@ class Config implements ConfigInterface
     /**
      * Create a new configuration object, and initialize it with
      * the provided nested array containing configuration data.
+     *
+     * @param array $data - Config data to store
      */
     public function __construct(array $data = null)
     {

--- a/src/Config.php
+++ b/src/Config.php
@@ -130,7 +130,7 @@ class Config implements ConfigInterface
     protected function getDefaults()
     {
         // Ensure $this->defaults is a Data object (not an array)
-        if (is_array($this->defaults)) {
+        if (!$this->defaults instanceof Data) {
             $this->setDefaults($this->defaults);
         }
         return $this->defaults;

--- a/src/Config.php
+++ b/src/Config.php
@@ -14,7 +14,7 @@ class Config implements ConfigInterface
      * TODO: make this private in 2.0 to prevent being saved as an array
      *   Making private now breaks backward compatibility
      *
-     * @var Data
+     * @var Data $defaults
      */
     protected $defaults;
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -132,11 +132,11 @@ class Config implements ConfigInterface
         if (is_array($this->defaults)) {
             $this->setDefaults($this->defaults);
             return $this->getDefaults();
-        } elseif ($this->defaults instanceof Data) {
-            return $this->defaults;
-        } else {
-            throw new \Exception('$this->defaults is not a DflyDev\DotAccessData\Data object');
         }
+        if ($this->defaults instanceof Data) {
+            return $this->defaults;
+        }
+        throw new \Exception('$this->defaults is not a DflyDev\DotAccessData\Data object');
     }
 
     /**

--- a/src/Config.php
+++ b/src/Config.php
@@ -1,10 +1,12 @@
 <?php
+
 namespace Consolidation\Config;
 
 use Dflydev\DotAccessData\Data;
 
 class Config implements ConfigInterface
 {
+
     /**
      * @var Data
      */
@@ -124,6 +126,7 @@ class Config implements ConfigInterface
      * TODO: remove Data object validation in 2.0
      *
      * @return Data
+     * @codeCoverageIgnore
      */
     protected function getDefaults()
     {
@@ -141,6 +144,7 @@ class Config implements ConfigInterface
      * @param Data|array $defaults
      *
      * @throws \Exception
+     * @codeCoverageIgnore
      */
     protected function setDefaults($defaults)
     {

--- a/src/Config.php
+++ b/src/Config.php
@@ -124,19 +124,14 @@ class Config implements ConfigInterface
      * TODO: remove Data object validation in 2.0
      *
      * @return Data
-     * @throws \Exception
      */
     protected function getDefaults()
     {
         // Ensure $this->defaults is a Data object (not an array)
         if (is_array($this->defaults)) {
             $this->setDefaults($this->defaults);
-            return $this->getDefaults();
         }
-        if ($this->defaults instanceof Data) {
-            return $this->defaults;
-        }
-        throw new \Exception('$this->defaults is not a DflyDev\DotAccessData\Data object');
+        return $this->defaults;
     }
 
     /**

--- a/src/Config.php
+++ b/src/Config.php
@@ -11,7 +11,7 @@ class Config implements ConfigInterface
     protected $config;
 
     /**
-     * @var array
+     * @var Data
      */
     protected $defaults;
 
@@ -22,7 +22,7 @@ class Config implements ConfigInterface
     public function __construct(array $data = null)
     {
         $this->config = new Data($data);
-        $this->defaults = [];
+        $this->defaults = new Data();
     }
 
     /**
@@ -94,7 +94,7 @@ class Config implements ConfigInterface
      */
     public function hasDefault($key)
     {
-        return isset($this->defaults[$key]);
+        return $this->defaults->has($key);
     }
 
     /**
@@ -102,7 +102,7 @@ class Config implements ConfigInterface
      */
     public function getDefault($key, $defaultFallback = null)
     {
-        return $this->hasDefault($key) ? $this->defaults[$key] : $defaultFallback;
+        return $this->hasDefault($key) ? $this->defaults->get($key) : $defaultFallback;
     }
 
     /**
@@ -110,7 +110,7 @@ class Config implements ConfigInterface
      */
     public function setDefault($key, $value)
     {
-        $this->defaults[$key] = $value;
+        $this->defaults->set($key, $value);
         return $this;
     }
 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -126,7 +126,6 @@ class Config implements ConfigInterface
      * TODO: remove Data object validation in 2.0
      *
      * @return Data
-     * @codeCoverageIgnore
      */
     protected function getDefaults()
     {
@@ -144,7 +143,6 @@ class Config implements ConfigInterface
      * @param Data|array $defaults
      *
      * @throws \Exception
-     * @codeCoverageIgnore
      */
     protected function setDefaults($defaults)
     {

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -38,16 +38,21 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
             'c' => 'boz',
         ];
 
+        $foo = ["foo" => "bar"];
+
         $config = new Config($data);
 
         $config->setDefault('c', 'other');
         $config->setDefault('d', 'other');
+        $config->setDefault('f', $foo);
 
         $this->assertEquals('foo', $config->get('a'));
         $this->assertEquals('boz', $config->get('c'));
         $this->assertEquals('other', $config->get('d'));
         $this->assertEquals('other', $config->getDefault('c'));
         $this->assertEquals('', $config->get('e'));
+        $this->assertEquals('bar', $config->get('f.foo'));
+        $this->assertEquals('{"foo":"bar"}', json_encode($config->get('f')));
     }
 
     public function testConfigurationWithCrossFileReferences()

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -55,6 +55,37 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('{"foo":"bar"}', json_encode($config->get('f')));
     }
 
+    public function testDefaultsArray()
+    {
+        $data = ['a' => 'foo', 'b' => 'bar', 'c' => 'boz',];
+        $defaults = ['d' => 'foo', 'e' => 'bar', 'f' => 'boz',];
+
+        // Create reflection class to test private methods
+        $configClass = new \ReflectionClass("Consolidation\Config\Config");
+
+        // $defaults
+        $defaultsProperty = $configClass->getProperty("defaults");
+        $defaultsProperty->setAccessible(true);
+
+        // $getDefaults
+        $getDefaultsMethod = $configClass->getMethod("getDefaults");
+        $getDefaultsMethod->setAccessible(true);
+
+        // Test the config class
+        $config = new Config($data);
+
+        // Set $config::defaults to an array to test getter and setter
+        $defaultsProperty->setValue($config, $defaults);
+        $this->assertTrue(is_array($defaultsProperty->getValue($config)));
+        $this->assertInstanceOf('Dflydev\DotAccessData\Data',
+            $getDefaultsMethod->invoke($config));
+
+        // Set $config::defaults to a string to test exception
+        $defaultsProperty->setValue($config, "foo.bar");
+        $this->setExpectedException("Exception");
+        $getDefaultsMethod->invoke($config);
+    }
+
     public function testConfigurationWithCrossFileReferences()
     {
         $config = new Config();


### PR DESCRIPTION
Fixes issue #7 

* Uses `Dflydev\DotAccessData\Data` to solve the problem. 
* Creates `getDefaults()` and `setDefaults($defaults)` methods to keep backwards compatibility
* Adds `TODO` comments for steps to enforce `$defaults` class parameter being a `Dflydev\DotAccessData\Data` object and not an array in version `2.0` (however this breaks backwards compatibility. 
* Updates appropriate tests to ensure new functionality is tested.