### PR TITLE
Avoid spurious duplicates in exports

### DIFF
--- a/src/Util/ConfigOverlay.php
+++ b/src/Util/ConfigOverlay.php
@@ -3,6 +3,7 @@ namespace Consolidation\Config\Util;
 
 use Consolidation\Config\Config;
 use Consolidation\Config\ConfigInterface;
+use Consolidation\Config\Util\ArrayUtil;
 
 /**
  * Overlay different configuration objects that implement ConfigInterface
@@ -171,7 +172,8 @@ class ConfigOverlay implements ConfigInterface
     {
         $export = [];
         foreach ($this->contexts as $name => $config) {
-            $export = array_merge_recursive($export, $config->export());
+            $exportToMerge = $config->export();
+            $export = ArrayUtil::mergeRecursiveDistinct($export, $exportToMerge);
         }
         return $export;
     }

--- a/tests/ConfigOverlayTest.php
+++ b/tests/ConfigOverlayTest.php
@@ -82,8 +82,16 @@ class ConfigOverlayTest extends \PHPUnit_Framework_TestCase
 
     public function testExport()
     {
+        // Set two different values in two contexts on the same key.
+        // Ensure that the value from only the higher-priority context
+        // shows up in the export.
+        $this->overlay->getContext('cf')->set('duplicate', 'cf-value');
+        $this->overlay->getContext('a')->set('duplicate', 'a-value');
         $data = $this->overlay->export();
 
+        $this->assertEquals('a-value', $data['duplicate']);
+
+        // Also ensure that we have some data from each context in the export.
         $this->assertEquals('config-file-a', $data['options']['cf-a']);
         $this->assertEquals('alias-a', $data['options']['a-a']);
     }


### PR DESCRIPTION
Ensure that duplicate keys added to different contexts in a config overlay only appear once in the final export.