### PR TITLE
Add interpolation to Config objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ $application->setDispatcher($eventDispatcher);
 
 
 ### Get Configuration Values
+
 If you have a configuration file that looks like this:
 ```
 a:
@@ -142,6 +143,19 @@ Then you can fetch the value of the configuration option `c` via:
 $value = $config->get('a.b.c');
 ```
 [dflydev/dot-access-data](https://github.com/dflydev/dot-access-data) is leveraged to provide this capability.
+
+### Interpolation
+
+Interpolation allows configuration values to be injected into a string with tokens. The tokens are used as keys that are looked up in the config object; the resulting configuration values will be used to replace the tokens in the provided string.
+
+For example, using the same configuration file shown above:
+```
+$result = $config->interpolate('The value is: {{a.b.c}}')
+```
+In this example, the `$result` string would be:
+```
+The value is: foo
+```
 
 ### Configuration Overlays
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -3,9 +3,12 @@
 namespace Consolidation\Config;
 
 use Dflydev\DotAccessData\Data;
+use Consolidation\Config\Util\ConfigInterpolatorInterface;
+use Consolidation\Config\Util\ConfigInterpolatorTrait;
 
-class Config implements ConfigInterface
+class Config implements ConfigInterface, ConfigInterpolatorInterface
 {
+    use ConfigInterpolatorTrait;
 
     /**
      * @var Data

--- a/src/Util/ConfigInterpolatorInterface.php
+++ b/src/Util/ConfigInterpolatorInterface.php
@@ -1,0 +1,37 @@
+<?php
+namespace Consolidation\Config\Util;
+
+use Consolidation\Config\Config;
+use Consolidation\Config\ConfigInterface;
+
+/**
+ * Provides configuration objects with an 'interpolate' method
+ * that may be used to inject config values into tokens embedded
+ * in strings.
+ */
+interface ConfigInterpolatorInterface extends ConfigInterface
+{
+    /**
+     * interpolate replaces tokens in a string with the correspnding
+     * value from this config object. Tokens are surrounded by double
+     * curley braces, e.g. "{{key}}".
+     *
+     * Example:
+     * If the message is 'Hello, {{user.name}}', then the key user.name
+     * is fetched from the config object, and the token {{user.name}} is
+     * replaced with the result.
+     *
+     * @param string $message Message containing tokens to be replaced
+     * @param string|bool $default The value to substitute for tokens that
+     *   are not found in the configuration. If `false`, then missing
+     *   tokens are not replaced.
+     * @return string
+     */
+    public function interpolate($message, $default = '');
+
+    /**
+     * mustInterpolate works exactly like interpolate, save for the fact
+     * that an exception is thrown is any of the tokens are not replaced.
+     */
+    public function mustInterpolate($message);
+}

--- a/src/Util/ConfigInterpolatorTrait.php
+++ b/src/Util/ConfigInterpolatorTrait.php
@@ -1,0 +1,73 @@
+<?php
+namespace Consolidation\Config\Util;
+
+use Consolidation\Config\Config;
+use Consolidation\Config\ConfigInterface;
+
+/**
+ * Provides configuration objects with an 'interpolate' method
+ * that may be used to inject config values into tokens embedded
+ * in strings..
+ */
+trait ConfigInterpolatorTrait
+{
+    /**
+     * @inheritdoc
+     */
+    public function interpolate($message, $default = '')
+    {
+        $replacements = $this->replacements($message, $default);
+        return strtr($message, $replacements);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function mustInterpolate($message)
+    {
+        $result = $this->interpolate($message, false);
+        $tokens = $this->findTokens($result);
+        if (!empty($tokens)) {
+            throw new \Exception('The following required keys were not found in configuration: ' . implode(',', $tokens));
+        }
+        return $result;
+    }
+
+    /**
+     * findTokens finds all of the tokens in the provided message
+     *
+     * @param string $message String with tokens
+     * @return string[] map of token to key, e.g. {{key}} => key
+     */
+    protected function findTokens($message)
+    {
+        if (!preg_match_all('#{{([a-zA-Z0-9._-]+)}}#', $message, $matches, PREG_SET_ORDER)) {
+            return [];
+        }
+        $tokens = [];
+        foreach ($matches as $matchSet) {
+            list($sourceText, $key) = $matchSet;
+            $tokens[$sourceText] = $key;
+        }
+        return $tokens;
+    }
+
+    /**
+     * Replacements looks up all of the replacements in the configuration
+     * object, given the token keys from the provided message. Keys that
+     * do not exist in the configuration are replaced with the default value.
+     */
+    protected function replacements($message, $default = '')
+    {
+        $tokens = $this->findTokens($message);
+
+        $replacements = [];
+        foreach ($tokens as $sourceText => $key) {
+            $replacementText = $this->get($key, $default);
+            if ($replacementText !== false) {
+                    $replacements[$sourceText] = $replacementText;
+            }
+        }
+        return $replacements;
+    }
+}

--- a/src/Util/ConfigInterpolatorTrait.php
+++ b/src/Util/ConfigInterpolatorTrait.php
@@ -11,13 +11,21 @@ use Consolidation\Config\ConfigInterface;
  */
 trait ConfigInterpolatorTrait
 {
+    protected $interpolator;
+
+    protected function getInterpolator()
+    {
+        if (!isset($this->interpolator)) {
+            $this->interpolator = new Interpolator();
+        }
+        return $this->interpolator;
+    }
     /**
      * @inheritdoc
      */
     public function interpolate($message, $default = '')
     {
-        $replacements = $this->replacements($message, $default);
-        return strtr($message, $replacements);
+        return $this->getInterpolator()->interpolate($this, $message, $default);
     }
 
     /**
@@ -25,49 +33,6 @@ trait ConfigInterpolatorTrait
      */
     public function mustInterpolate($message)
     {
-        $result = $this->interpolate($message, false);
-        $tokens = $this->findTokens($result);
-        if (!empty($tokens)) {
-            throw new \Exception('The following required keys were not found in configuration: ' . implode(',', $tokens));
-        }
-        return $result;
-    }
-
-    /**
-     * findTokens finds all of the tokens in the provided message
-     *
-     * @param string $message String with tokens
-     * @return string[] map of token to key, e.g. {{key}} => key
-     */
-    protected function findTokens($message)
-    {
-        if (!preg_match_all('#{{([a-zA-Z0-9._-]+)}}#', $message, $matches, PREG_SET_ORDER)) {
-            return [];
-        }
-        $tokens = [];
-        foreach ($matches as $matchSet) {
-            list($sourceText, $key) = $matchSet;
-            $tokens[$sourceText] = $key;
-        }
-        return $tokens;
-    }
-
-    /**
-     * Replacements looks up all of the replacements in the configuration
-     * object, given the token keys from the provided message. Keys that
-     * do not exist in the configuration are replaced with the default value.
-     */
-    protected function replacements($message, $default = '')
-    {
-        $tokens = $this->findTokens($message);
-
-        $replacements = [];
-        foreach ($tokens as $sourceText => $key) {
-            $replacementText = $this->get($key, $default);
-            if ($replacementText !== false) {
-                    $replacements[$sourceText] = $replacementText;
-            }
-        }
-        return $replacements;
+        return $this->getInterpolator()->mustInterpolate($this, $message);
     }
 }

--- a/src/Util/ConfigOverlay.php
+++ b/src/Util/ConfigOverlay.php
@@ -4,6 +4,8 @@ namespace Consolidation\Config\Util;
 use Consolidation\Config\Config;
 use Consolidation\Config\ConfigInterface;
 use Consolidation\Config\Util\ArrayUtil;
+use Consolidation\Config\Util\ConfigInterpolatorInterface;
+use Consolidation\Config\Util\ConfigInterpolatorTrait;
 
 /**
  * Overlay different configuration objects that implement ConfigInterface
@@ -13,8 +15,9 @@ use Consolidation\Config\Util\ArrayUtil;
  * individual configuration context. When using overlays, always call
  * getDefault / setDefault on the ConfigOverlay object itself.
  */
-class ConfigOverlay implements ConfigInterface
+class ConfigOverlay implements ConfigInterface, ConfigInterpolatorInterface
 {
+    use ConfigInterpolatorTrait;
     protected $contexts = [];
 
     const DEFAULT_CONTEXT = 'default';

--- a/src/Util/Interpolator.php
+++ b/src/Util/Interpolator.php
@@ -70,7 +70,7 @@ class Interpolator
      * object, given the token keys from the provided message. Keys that
      * do not exist in the configuration are replaced with the default value.
      */
-    protected function replacements($data, $message, $default = '')
+    public function replacements($data, $message, $default = '')
     {
         $tokens = $this->findTokens($message);
 

--- a/src/Util/Interpolator.php
+++ b/src/Util/Interpolator.php
@@ -1,0 +1,97 @@
+<?php
+namespace Consolidation\Config\Util;
+
+use Consolidation\Config\Config;
+use Consolidation\Config\ConfigInterface;
+
+/**
+ * Provides configuration objects with an 'interpolate' method
+ * that may be used to inject config values into tokens embedded
+ * in strings..
+ */
+class Interpolator
+{
+    /**
+     * interpolate replaces tokens in a string with the correspnding
+     * value from this config object. Tokens are surrounded by double
+     * curley braces, e.g. "{{key}}".
+     *
+     * Example:
+     * If the message is 'Hello, {{user.name}}', then the key user.name
+     * is fetched from the config object, and the token {{user.name}} is
+     * replaced with the result.
+     *
+     * @param string $message Message containing tokens to be replaced
+     * @param string|bool $default The value to substitute for tokens that
+     *   are not found in the configuration. If `false`, then missing
+     *   tokens are not replaced.
+     * @return string
+     */
+    public function interpolate($data, $message, $default = '')
+    {
+        $replacements = $this->replacements($data, $message, $default);
+        return strtr($message, $replacements);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function mustInterpolate($data, $message)
+    {
+        $result = $this->interpolate($data, $message, false);
+        $tokens = $this->findTokens($result);
+        if (!empty($tokens)) {
+            throw new \Exception('The following required keys were not found in configuration: ' . implode(',', $tokens));
+        }
+        return $result;
+    }
+
+    /**
+     * findTokens finds all of the tokens in the provided message
+     *
+     * @param string $message String with tokens
+     * @return string[] map of token to key, e.g. {{key}} => key
+     */
+    public function findTokens($message)
+    {
+        if (!preg_match_all('#{{([a-zA-Z0-9._-]+)}}#', $message, $matches, PREG_SET_ORDER)) {
+            return [];
+        }
+        $tokens = [];
+        foreach ($matches as $matchSet) {
+            list($sourceText, $key) = $matchSet;
+            $tokens[$sourceText] = $key;
+        }
+        return $tokens;
+    }
+
+    /**
+     * Replacements looks up all of the replacements in the configuration
+     * object, given the token keys from the provided message. Keys that
+     * do not exist in the configuration are replaced with the default value.
+     */
+    protected function replacements($data, $message, $default = '')
+    {
+        $tokens = $this->findTokens($message);
+
+        $replacements = [];
+        foreach ($tokens as $sourceText => $key) {
+            $replacementText = $this->get($data, $key, $default);
+            if ($replacementText !== false) {
+                    $replacements[$sourceText] = $replacementText;
+            }
+        }
+        return $replacements;
+    }
+
+    protected function get($data, $key, $default)
+    {
+        if (is_array($data)) {
+            return array_key_exists($key, $data) ? $data[$key] : $default;
+        }
+        if ($data instanceof ConfigInterface) {
+            return $data->get($key, $default);
+        }
+        throw new \Exception('Bad data type provided to Interpolator');
+    }
+}

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -55,6 +55,46 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('{"foo":"bar"}', json_encode($config->get('f')));
     }
 
+    public function testGetTokens()
+    {
+        $data = [
+            'a' => [
+                'b' => [
+                    'c' => 'foo',
+                ],
+            ],
+        ];
+
+        // Create reflection class to test private methods
+        $configClass = new \ReflectionClass("Consolidation\Config\Config");
+
+        // $findTokens
+        $findTokensMethod = $configClass->getMethod("findTokens");
+        $findTokensMethod->setAccessible(true);
+
+        // Test the config class
+        $config = new Config($data);
+
+        $tokens = $findTokensMethod->invoke($config, 'This is a {{a.b.c}} bar with a {{x.y}}');
+        $this->assertEquals('a.b.c:x.y', implode(':', $tokens));
+    }
+
+    public function testInterpolation()
+    {
+        $data = [
+            'a' => [
+                'b' => [
+                    'c' => 'foo',
+                ],
+            ],
+        ];
+        $config = new Config($data);
+
+        $actual = $config->interpolate('This is a {{a.b.c}} bar');
+
+        $this->assertEquals('This is a foo bar', $actual);
+    }
+
     public function testDefaultsArray()
     {
         $data = ['a' => 'foo', 'b' => 'bar', 'c' => 'boz',];

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -3,6 +3,7 @@ namespace Consolidation\Config;
 
 use Consolidation\Config\Loader\ConfigProcessor;
 use Consolidation\Config\Loader\YamlConfigLoader;
+use Consolidation\Config\Util\Interpolator;
 
 class ConfigTest extends \PHPUnit_Framework_TestCase
 {
@@ -53,30 +54,6 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('', $config->get('e'));
         $this->assertEquals('bar', $config->get('f.foo'));
         $this->assertEquals('{"foo":"bar"}', json_encode($config->get('f')));
-    }
-
-    public function testGetTokens()
-    {
-        $data = [
-            'a' => [
-                'b' => [
-                    'c' => 'foo',
-                ],
-            ],
-        ];
-
-        // Create reflection class to test private methods
-        $configClass = new \ReflectionClass("Consolidation\Config\Config");
-
-        // $findTokens
-        $findTokensMethod = $configClass->getMethod("findTokens");
-        $findTokensMethod->setAccessible(true);
-
-        // Test the config class
-        $config = new Config($data);
-
-        $tokens = $findTokensMethod->invoke($config, 'This is a {{a.b.c}} bar with a {{x.y}}');
-        $this->assertEquals('a.b.c:x.y', implode(':', $tokens));
     }
 
     public function testInterpolation()

--- a/tests/InterpolatorTest.php
+++ b/tests/InterpolatorTest.php
@@ -14,4 +14,49 @@ class InterpolatorTest extends \PHPUnit_Framework_TestCase
         $tokens = $interpolator->findTokens('This is a {{a.b.c}} bar with a {{x.y}}');
         $this->assertEquals('a.b.c:x.y', implode(':', $tokens));
     }
+
+    public function testReplacements()
+    {
+        $interpolator = new Interpolator();
+
+        $data = ['a.b.c' => 'foo'];
+        $replacements = $interpolator->replacements($data, 'This is a {{a.b.c}} bar with a {{x.y}}', 'default');
+
+        $this->assertEquals('{"{{a.b.c}}":"foo","{{x.y}}":"default"}', json_encode($replacements, true));
+    }
+
+    public function inerpolatorTestValues()
+    {
+        return [
+            [
+                'the result is bar',
+                'the result is {{foo}}',
+                ['foo' => 'bar'],
+                'default',
+            ],
+            [
+                'the result is default',
+                'the result is {{foo}}',
+                ['a' => 'b'],
+                'default',
+            ],
+            [
+                'the result is {{foo}}',
+                'the result is {{foo}}',
+                ['a' => 'b'],
+                false,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider inerpolatorTestValues
+     */
+    public function testInterpolator($expected, $message, $data, $default)
+    {
+        $interpolator = new Interpolator();
+
+        $actual = $interpolator->interpolate($data, $message, $default);
+        $this->assertEquals($expected, $actual);
+    }
 }

--- a/tests/InterpolatorTest.php
+++ b/tests/InterpolatorTest.php
@@ -1,0 +1,17 @@
+<?php
+namespace Consolidation\Config;
+
+use Consolidation\Config\Loader\ConfigProcessor;
+use Consolidation\Config\Loader\YamlConfigLoader;
+use Consolidation\Config\Util\Interpolator;
+
+class InterpolatorTest extends \PHPUnit_Framework_TestCase
+{
+    public function testFindTokens()
+    {
+        $interpolator = new Interpolator();
+
+        $tokens = $interpolator->findTokens('This is a {{a.b.c}} bar with a {{x.y}}');
+        $this->assertEquals('a.b.c:x.y', implode(':', $tokens));
+    }
+}


### PR DESCRIPTION
This PR interpolates values into tokens delimited by double-curley braces.

Example:  `$config->interpolate('This is a {{a.b.c}} bar');`

This is a departure from how variables are defined and substituted at parsing time, where `${name}` is used instead. It would be possible to be consistent, but consistency would make it harder to pull strings out of configuration and use them as interpolation templates. I'm not sure if this use-case is important or desirable.