### PR TITLE
Make Codecov run again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,5 +155,5 @@ jobs:
         run: composer unit
       
       - name: Publish code coverage to Codecov
-        if: env.CODECOV_TOKEN && matrix.os == 'ubuntu-latest' && matrix.php-version == '8.0'
+        if: matrix.os == 'ubuntu-latest' && matrix.php-version == '8.0'
         run: bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
The env.NAME variable can only be used to access environment variables set by a workflow.