### PR TITLE
Fix default value type

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -30,7 +30,7 @@ class Config implements ConfigInterface, ConfigInterpolatorInterface
      * @param array $data
      *   Config data to store.
      */
-    public function __construct(array $data = null)
+    public function __construct(array $data = [])
     {
         $this->config = new Data($data);
         $this->setDefaults(new Data());

--- a/src/Config.php
+++ b/src/Config.php
@@ -30,9 +30,9 @@ class Config implements ConfigInterface, ConfigInterpolatorInterface
      * @param array $data
      *   Config data to store.
      */
-    public function __construct(array $data = [])
+    public function __construct(array $data = null)
     {
-        $this->config = new Data($data);
+        $this->config = new Data($data ?: []);
         $this->setDefaults(new Data());
     }
 


### PR DESCRIPTION
\Dflydev\DotAccessData\Data constructor parameter now it has a strict typing for array. When you create Config without parameters, it will send null to Data constructor, which will cause an error