### PR TITLE
Bugfix NULL sent to Dflydev\DotAccessData\Data

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -77,7 +77,7 @@ class Config implements ConfigInterface, ConfigInterpolatorInterface
      */
     public function replace($data)
     {
-        $this->config = new Data($data);
+        $this->config = new Data($data ?: []);
         return $this;
     }
 


### PR DESCRIPTION
Newer Dflydev\DotAccessData\Data does not allow NULL to be sent in the construct. So if it is null, send an empty array.

This fixes a problem with running https://github.com/consolidation/robo commands since the upgrade from 2.0.3 to 2.0.4 of this repo.