### PR TITLE
PHP 8.2 compatibility: ${} string interpolation deprecated

### DIFF
--- a/src/Util/ArrayUtil.php
+++ b/src/Util/ArrayUtil.php
@@ -92,7 +92,7 @@ class ArrayUtil
             if (self::selectMerge($keyPrefix, $key, $selectionList)) {
                 return array_merge_recursive($merged[$key], $value);
             } else {
-                return self::mergeRecursiveSelect($merged[$key], $value, $selectionList, "${keyPrefix}${key}.");
+                return self::mergeRecursiveSelect($merged[$key], $value, $selectionList, "{$keyPrefix}{$key}.");
             }
         }
         return $value;
@@ -107,7 +107,7 @@ class ArrayUtil
      */
     protected static function selectMerge($keyPrefix, $key, $selectionList)
     {
-        return in_array("${keyPrefix}${key}", $selectionList);
+        return in_array("{$keyPrefix}{$key}", $selectionList);
     }
 
 

--- a/src/Util/ConfigFallback.php
+++ b/src/Util/ConfigFallback.php
@@ -37,7 +37,7 @@ class ConfigFallback extends ConfigGroup
      */
     protected function getWithFallback($key, $group, $prefix = '', $postfix = '.')
     {
-        $configKey = "{$prefix}{$group}${postfix}{$key}";
+        $configKey = "{$prefix}{$group}{$postfix}{$key}";
         if ($this->config->has($configKey)) {
             return $this->config->get($configKey);
         }

--- a/src/Util/ConfigMerge.php
+++ b/src/Util/ConfigMerge.php
@@ -28,7 +28,7 @@ class ConfigMerge extends ConfigGroup
      */
     public function getWithMerge($key, $group, $prefix = '', $postfix = '.')
     {
-        $configKey = "{$prefix}{$group}${postfix}{$key}";
+        $configKey = "{$prefix}{$group}{$postfix}{$key}";
         $result = $this->config->get($configKey, []);
         if (!is_array($result)) {
             throw new \UnexpectedValueException($configKey . ' must be a list of settings to apply.');


### PR DESCRIPTION
https://php.watch/versions/8.2/$%7Bvar%7D-string-interpolation-deprecated

Ref https://github.com/drush-ops/drush/issues/5168